### PR TITLE
Adding initial library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+minimq = "0.5"
+heapless = {version = "0.7", features = ["serde"] }
+serde-json-core = "0.4"
+log = "0.4"
+serde = { version = "1", features = ["derive"], default-features = false }
+smlang = "0.5"
+
+[dev-dependencies]
+std-embedded-nal = "0.1"
+std-embedded-time = "0.1"
+tokio = { version = "1.9", features = ["rt-multi-thread", "time", "macros"] }
+env_logger = "0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,278 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
+#![no_std]
+/// MQTT Request/response Handling
+///
+/// # Overview
+/// This library is intended to be an easy way to handle inbound requests automatically.
+///
+/// Handler functions can be associated with the library to be automatically called whenever a
+/// specified request is received, and the handler will automatically be invoked when the request
+/// is received.
+///
+/// ## Limitations
+/// * The `poll()` function has a somewhat odd signature (using a function to provide the `Context`
+/// and call the handler) due to required compatibility with RTIC and unlocked resources.
+///
+/// * Handlers may only be closures that do not capture any local resources. Instead, move local
+/// captures into the `Context`, which will be provided to the handler in the function call.
+///
+use core::fmt::Write;
+
+use minimq::{
+    embedded_nal::{IpAddr, TcpClientStack},
+    embedded_time, Property, QoS, Retain,
+};
+
+use serde_json_core::heapless::{String, Vec};
+
+use log::{info, warn};
+
+pub mod response;
+pub use response::Response;
+
+// The maximum topic length of any settings path.
+const MAX_TOPIC_LENGTH: usize = 128;
+
+// The keepalive interval to use for MQTT in seconds.
+const KEEPALIVE_INTERVAL_SECONDS: u16 = 60;
+
+#[derive(Debug, PartialEq)]
+pub enum Error<E> {
+    RegisterFailed,
+    PrefixTooLong,
+    Deserialization(serde_json_core::de::Error),
+    Mqtt(minimq::Error<E>),
+}
+
+impl<E> From<serde_json_core::de::Error> for Error<E> {
+    fn from(e: serde_json_core::de::Error) -> Self {
+        Error::Deserialization(e)
+    }
+}
+
+impl<E> From<minimq::Error<E>> for Error<E> {
+    fn from(e: minimq::Error<E>) -> Self {
+        Error::Mqtt(e)
+    }
+}
+
+mod sm {
+    smlang::statemachine! {
+        transitions: {
+            *Init + Connected = Connected,
+            Connected + Subscribed = Active,
+            _ + Reset = Init,
+        }
+    }
+
+    pub struct Context;
+
+    impl StateMachineContext for Context {}
+}
+
+type Handler<Context, E> = fn(&mut Context, &str, &[u8]) -> Result<Response, Error<E>>;
+
+/// MQTT request/response interface.
+pub struct Minireq<Context, Stack, Clock, const MESSAGE_SIZE: usize>
+where
+    Stack: TcpClientStack,
+    Clock: embedded_time::Clock,
+{
+    // TODO: Maybe use a hash-based IndexMap?
+    requests: heapless::LinearMap<String<60>, Handler<Context, Stack::Error>, 10>,
+    mqtt: minimq::Minimq<Stack, Clock, MESSAGE_SIZE, 1>,
+    prefix: String<MAX_TOPIC_LENGTH>,
+    state: sm::StateMachine<sm::Context>,
+}
+
+impl<Context, Stack, Clock, const MESSAGE_SIZE: usize> Minireq<Context, Stack, Clock, MESSAGE_SIZE>
+where
+    Stack: TcpClientStack,
+    Clock: embedded_time::Clock + Clone,
+{
+    /// Construct a new MQTT request handler.
+    ///
+    /// # Args
+    /// * `stack` - The network stack to use for communication.
+    /// * `client_id` - The ID of the MQTT client. May be an empty string for auto-assigning.
+    /// * `device_prefix` - The MQTT device prefix to use for this device.
+    /// * `broker` - The IP address of the MQTT broker to use.
+    /// * `clock` - The clock for managing the MQTT connection.
+    pub fn new(
+        stack: Stack,
+        client_id: &str,
+        device_prefix: &str,
+        broker: IpAddr,
+        clock: Clock,
+    ) -> Result<Self, Error<Stack::Error>> {
+        let mut mqtt = minimq::Minimq::new(broker, client_id, stack, clock.clone())?;
+
+        // Note(unwrap): The client was just created, so it's valid to set a keepalive interval
+        // now, since we're not yet connected to the broker.
+        mqtt.client
+            .set_keepalive_interval(KEEPALIVE_INTERVAL_SECONDS)
+            .unwrap();
+
+        // Note(unwrap): The user must provide a prefix of the correct size.
+        let mut prefix: String<MAX_TOPIC_LENGTH> = String::new();
+        write!(&mut prefix, "{}/command", device_prefix).map_err(|_| Error::PrefixTooLong)?;
+
+        Ok(Self {
+            requests: heapless::LinearMap::default(),
+            mqtt,
+            prefix,
+            state: sm::StateMachine::new(sm::Context),
+        })
+    }
+
+    /// Associate a handler to be called when receiving the specified request.
+    ///
+    /// # Args
+    /// * `topic` - The request to register the provided handler with.
+    /// * `handler` - The handler function to be called when the request occurs.
+    pub fn register_request(
+        &mut self,
+        topic: &str,
+        handler: Handler<Context, Stack::Error>,
+    ) -> Result<bool, Error<Stack::Error>> {
+        self.requests
+            .insert(String::from(topic), handler)
+            .map(|prev| prev.is_none())
+            .map_err(|_| Error::RegisterFailed)
+    }
+
+    fn _handle_mqtt<F>(&mut self, mut f: F) -> Result<(), Error<Stack::Error>>
+    where
+        F: FnMut(
+            Handler<Context, Stack::Error>,
+            &str,
+            &[u8],
+        ) -> Result<Response, Error<Stack::Error>>,
+    {
+        let Self {
+            requests,
+            mqtt,
+            prefix,
+            ..
+        } = self;
+
+        match mqtt.poll(|client, topic, message, properties| {
+            let path = match topic.strip_prefix(prefix.as_str()) {
+                // For paths, we do not want to include the leading slash.
+                Some(path) => {
+                    if !path.is_empty() {
+                        &path[1..]
+                    } else {
+                        path
+                    }
+                }
+                None => {
+                    info!("Unexpected MQTT topic: {}", topic);
+                    return;
+                }
+            };
+
+            // Extract the response topic
+            let response_topic = match properties.iter().find_map(|prop| {
+                if let Property::ResponseTopic(topic) = prop {
+                    Some(topic)
+                } else {
+                    None
+                }
+            }) {
+                Some(topic) => topic,
+                None => {
+                    warn!("Ignoring inbound request with no response topic");
+                    return;
+                }
+            };
+
+            // Extract correlation data
+            let mut response_props: Vec<minimq::Property, 1> = Vec::new();
+            if let Some(cd) = properties
+                .iter()
+                .find(|prop| matches!(prop, minimq::Property::CorrelationData(_)))
+            {
+                // Note(unwrap): We guarantee there is space for this item.
+                response_props.push(*cd).unwrap();
+            }
+
+            // Perform the action
+            let response = match requests.get(&String::from(path)) {
+                Some(&handler) => f(handler, path, message).unwrap_or_else(Response::error),
+                None => Response::custom(-1, "Unregistered request"),
+            };
+
+            // Note(unwrap): We currently have no means of indicating a response that is too long.
+            // TODO: We should return this as an error in the future.
+            let mut serialized_response = [0u8; MESSAGE_SIZE];
+            let len = serde_json_core::to_slice(&response, &mut serialized_response).unwrap();
+
+            client
+                .publish(
+                    response_topic,
+                    &serialized_response[..len],
+                    // TODO: When Minimq supports more QoS levels, this should be increased to
+                    // ensure that the client has received it at least once.
+                    QoS::AtMostOnce,
+                    Retain::NotRetained,
+                    &response_props,
+                )
+                .ok();
+        }) {
+            Ok(_) => Ok(()),
+            Err(minimq::Error::SessionReset) => {
+                // Note(unwrap): It's always safe to unwrap the reset event. All states must handle
+                // it.
+                self.state.process_event(sm::Events::Reset).unwrap();
+                Ok(())
+            }
+            Err(other) => Err(Error::Mqtt(other)),
+        }
+    }
+
+    /// Poll the request/response interface.
+    ///
+    /// # Args
+    /// * `f` - A function that will be called with the provided handler, command, and data. This
+    /// function is responsible for calling the handler with the necessary context.
+    ///
+    /// # Note
+    /// Any incoming requests will be automatically handled using provided handlers.
+    pub fn poll<F>(&mut self, f: F) -> Result<(), Error<Stack::Error>>
+    where
+        F: FnMut(
+            Handler<Context, Stack::Error>,
+            &str,
+            &[u8],
+        ) -> Result<Response, Error<Stack::Error>>,
+    {
+        if !self.mqtt.client.is_connected() {
+            // Note(unwrap): It's always safe to unwrap the reset event. All states must handle it.
+            self.state.process_event(sm::Events::Reset).unwrap();
+        }
+
+        match *self.state.state() {
+            sm::States::Init => {
+                if self.mqtt.client.is_connected() {
+                    // Note(unwrap): It's always safe to process this event in the INIT state.
+                    self.state.process_event(sm::Events::Connected).unwrap();
+                }
+            }
+            sm::States::Connected => {
+                // Note(unwrap): We ensure that this storage is always sufficiently large to store
+                // the wildcard post-fix for MQTT.
+                let mut prefix: String<{ MAX_TOPIC_LENGTH + 2 }> =
+                    String::from(self.prefix.as_str());
+                prefix.push_str("/#").unwrap();
+
+                if self.mqtt.client.subscribe(&prefix, &[]).is_ok() {
+                    // Note(unwrap): It is always safe to process a Subscribed event in this state.
+                    self.state.process_event(sm::Events::Subscribed).unwrap();
+                }
+            }
+            sm::States::Active => {}
+        }
+
+        self._handle_mqtt(f)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ impl<Context, Stack, Clock, const MESSAGE_SIZE: usize, const NUM_REQUESTS: usize
     Minireq<Context, Stack, Clock, MESSAGE_SIZE, NUM_REQUESTS>
 where
     Stack: TcpClientStack,
-    Clock: embedded_time::Clock + Clone,
+    Clock: embedded_time::Clock,
 {
     /// Construct a new MQTT request handler.
     ///
@@ -109,7 +109,7 @@ where
         broker: IpAddr,
         clock: Clock,
     ) -> Result<Self, Error<Stack::Error>> {
-        let mut mqtt = minimq::Minimq::new(broker, client_id, stack, clock.clone())?;
+        let mut mqtt = minimq::Minimq::new(broker, client_id, stack, clock)?;
 
         // Note(unwrap): The client was just created, so it's valid to set a keepalive interval
         // now, since we're not yet connected to the broker.

--- a/src/response.rs
+++ b/src/response.rs
@@ -22,7 +22,7 @@ impl<const MAX_RESPONSE_SIZE: usize> Response<MAX_RESPONSE_SIZE> {
         if write!(&mut msg, "{:?}", err).is_err() {
             msg = String::from("Error");
         }
-        Self::custom(-1, &msg.as_str())
+        Self::custom(-1, &msg)
     }
 
     /// A response with json-serialized data indicating success.

--- a/src/response.rs
+++ b/src/response.rs
@@ -3,17 +3,14 @@ use serde::{Deserialize, Serialize};
 
 use heapless::{String, Vec};
 
-// The maximum size of a response.
-const MAX_RESPONSE_SIZE: usize = 128;
-
 /// Responses are always generated as a result of handling an in-bound request.
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
-pub struct Response {
+pub struct Response<const MAX_RESPONSE_SIZE: usize> {
     pub code: i32,
     pub data: Vec<u8, MAX_RESPONSE_SIZE>,
 }
 
-impl Response {
+impl<const MAX_RESPONSE_SIZE: usize> Response<MAX_RESPONSE_SIZE> {
     /// A response without data indicating success.
     pub fn ok() -> Self {
         Self::custom(0, "Ok")

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,0 +1,59 @@
+use core::fmt::{Debug, Write};
+use serde::{Deserialize, Serialize};
+
+use heapless::{String, Vec};
+
+// The maximum size of a response.
+const MAX_RESPONSE_SIZE: usize = 128;
+
+/// Responses are always generated as a result of handling an in-bound request.
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct Response {
+    pub code: i32,
+    pub data: Vec<u8, MAX_RESPONSE_SIZE>,
+}
+
+impl Response {
+    /// A response without data indicating success.
+    pub fn ok() -> Self {
+        Self::custom(0, "Ok")
+    }
+
+    /// A response indicating failure with some error code.
+    pub fn error(err: impl Debug) -> Self {
+        let mut msg: String<MAX_RESPONSE_SIZE> = String::new();
+        if write!(&mut msg, "{:?}", err).is_err() {
+            msg = String::from("Error");
+        }
+        Self::custom(-1, &msg.as_str())
+    }
+
+    /// A response with json-serialized data indicating success.
+    ///
+    /// # Note
+    /// If the provided `response` cannot fit into the message, an error will be returned instead.
+    pub fn data(response: impl Serialize) -> Self {
+        let mut data = Vec::new();
+        data.resize(data.capacity(), 0).unwrap();
+        let len = match serde_json_core::to_slice(&response, &mut data[..]) {
+            Ok(len) => len,
+            Err(_) => return Self::custom(-2, "Response too large"),
+        };
+
+        data.resize(len, 0).unwrap();
+
+        Self { code: 0, data }
+    }
+
+    /// A custom response type using the provided code and message.
+    pub fn custom(code: i32, message: &str) -> Self {
+        let mut data = Vec::new();
+
+        if data.write_str(message).is_err() {
+            // Note(unwrap): This string should always fit in the data vector.
+            data.write_str("Truncated").unwrap();
+        }
+
+        Self { code, data }
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -66,7 +66,7 @@ async fn main() {
     tokio::task::spawn(async move { client_task().await });
 
     // Construct a settings configuration interface.
-    let mut interface: minireq::Minireq<bool, _, _, 256> = minireq::Minireq::new(
+    let mut interface: minireq::Minireq<bool, _, _, 256, 1> = minireq::Minireq::new(
         Stack::default(),
         "tester-device",
         "minireq/integration/device",
@@ -76,7 +76,7 @@ async fn main() {
     .unwrap();
 
     interface
-        .register_request("test", |exit, _req, _data| {
+        .register("test", |exit, _req, _data| {
             *exit = true;
             Ok(Response::ok())
         })

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -44,7 +44,7 @@ async fn client_task() {
     let mut continue_testing = true;
     loop {
         mqtt.poll(|_client, _topic, message, _properties| {
-            let data: Response = serde_json_core::from_slice(message).unwrap().0;
+            let data: Response<128> = serde_json_core::from_slice(message).unwrap().0;
             assert!(data.code != 0);
             continue_testing = false;
         })

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,93 @@
+use minimq;
+use minireq::Response;
+use std_embedded_nal::Stack;
+use std_embedded_time::StandardClock;
+
+async fn client_task() {
+    // Construct a Minimq client to the broker for publishing requests.
+    let mut mqtt: minimq::Minimq<_, _, 256, 1> = minimq::Minimq::new(
+        "127.0.0.1".parse().unwrap(),
+        "tester-client",
+        Stack::default(),
+        StandardClock::default(),
+    )
+    .unwrap();
+
+    // Wait for the broker connection
+    while !mqtt.client.is_connected() {
+        mqtt.poll(|_client, _topic, _message, _properties| {})
+            .unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    }
+
+    let response_topic = "minireq/integration/device/response";
+    mqtt.client.subscribe(&response_topic, &[]).unwrap();
+
+    // Wait the other device to connect.
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+    // Configure the error variable to trigger an internal validation failure.
+    let properties = [minimq::Property::ResponseTopic(&response_topic)];
+
+    log::info!("Publishing error setting");
+    mqtt.client
+        .publish(
+            "minireq/integration/device/command/test",
+            b"true",
+            minimq::QoS::AtMostOnce,
+            minimq::Retain::NotRetained,
+            &properties,
+        )
+        .unwrap();
+
+    // Wait until we get a response to the request.
+    let mut continue_testing = true;
+    loop {
+        mqtt.poll(|_client, _topic, message, _properties| {
+            let data: Response = serde_json_core::from_slice(message).unwrap().0;
+            assert!(data.code != 0);
+            continue_testing = false;
+        })
+        .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+        if !continue_testing {
+            break;
+        }
+    }
+}
+
+#[tokio::test]
+async fn main() {
+    env_logger::init();
+
+    // Spawn a task to send MQTT messages.
+    tokio::task::spawn(async move { client_task().await });
+
+    // Construct a settings configuration interface.
+    let mut interface: minireq::Minireq<bool, _, _, 256> = minireq::Minireq::new(
+        Stack::default(),
+        "tester-device",
+        "minireq/integration/device",
+        "127.0.0.1".parse().unwrap(),
+        StandardClock::default(),
+    )
+    .unwrap();
+
+    interface
+        .register_request("test", |exit, _req, _data| {
+            *exit = true;
+            Ok(Response::ok())
+        })
+        .unwrap();
+
+    // Update the client until the exit
+    let mut should_exit = false;
+    while !should_exit {
+        interface
+            .poll(|handler, topic, data| handler(&mut should_exit, topic, data))
+            .unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+    }
+}


### PR DESCRIPTION
First pass at the request/response library

Adds the basic library + a minimal MQTT integration test.

This operates using the device prefix identical to miniconf. The `<prefix>/command/#` path is subscribed to by the client.

The basic idea is that after you construct the client, you can register endpoints:
```rust
minireq.register("my_request", |ctx, _request_path, _request_data| {
    Ok(minireq::Response::ok())
}).unwrap();
```

Then, in the `idle()` loop, you continuously poll it for updates, where it will automatically invoke the provided handlers:
```rust
// Ctx provided from elsewhere...
minireq.poll(|handler, path, data| handler(ctx, path, data)).unwrap();
```

TODO:
- [x] Fix clippy lints