### PR TITLE
Properly handling large responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+### Fixed
+* [#3](https://github.com/quartiq/minireq/issues/3) Fixed an issue where large responses would trigger an internal panic
 
 ## [0.1.0] - 2022-03-28
 


### PR DESCRIPTION
This PR fixes #3 by dropping the response and generating a log if the response is too large.