### PR TITLE
Serializing response data as a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Fixed
 * [#3](https://github.com/quartiq/minireq/issues/3) Fixed an issue where large responses would trigger an internal panic
+* [#7](https://github.com/quartiq/minireq/issues/7) Fixed serialization of responses so they are readable
 
 ## [0.1.0] - 2022-03-28
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,13 +1,13 @@
 use core::fmt::{Debug, Write};
 use serde::{Deserialize, Serialize};
 
-use heapless::{String, Vec};
+use heapless::String;
 
 /// Responses are always generated as a result of handling an in-bound request.
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct Response<const MAX_RESPONSE_SIZE: usize> {
     pub code: i32,
-    pub data: Vec<u8, MAX_RESPONSE_SIZE>,
+    pub data: String<MAX_RESPONSE_SIZE>,
 }
 
 impl<const MAX_RESPONSE_SIZE: usize> Response<MAX_RESPONSE_SIZE> {
@@ -30,25 +30,20 @@ impl<const MAX_RESPONSE_SIZE: usize> Response<MAX_RESPONSE_SIZE> {
     /// # Note
     /// If the provided `response` cannot fit into the message, an error will be returned instead.
     pub fn data(response: impl Serialize) -> Self {
-        let mut data = Vec::new();
-        data.resize(data.capacity(), 0).unwrap();
-        let len = match serde_json_core::to_slice(&response, &mut data[..]) {
-            Ok(len) => len,
+        let data = match serde_json_core::to_string(&response) {
+            Ok(data) => data,
             Err(_) => return Self::custom(-2, "Response too large"),
         };
-
-        data.resize(len, 0).unwrap();
 
         Self { code: 0, data }
     }
 
     /// A custom response type using the provided code and message.
     pub fn custom(code: i32, message: &str) -> Self {
-        let mut data = Vec::new();
+        let mut data = String::new();
 
-        if data.write_str(message).is_err() {
-            // Note(unwrap): This string should always fit in the data vector.
-            data.write_str("Truncated").unwrap();
+        if data.push_str(message).is_err() {
+            data = String::from("Truncated");
         }
 
         Self { code, data }


### PR DESCRIPTION
This PR fixes #7 by serializing response data into `String` instead of `Vec` to transfer responses back to the host. 
Sample response from Booster:
```
{"code":0,"data":"{\"vgs\":-1.189,\"ids\":0.049717817}"}
```