### PR TITLE
bump std-embedded-nal v0.2, other deps, release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.3.0] - 2023-11-01
 
 * Handlers now take a fourth argument, `output_buffer`, where they can serialize their response into
 directly
@@ -34,6 +34,7 @@ command is registered.
 
 Library initially released on crates.io
 
+[0.3.0]: https://github.com/quartiq/minireq/releases/tag/v0.3.0
 [0.2.0]: https://github.com/quartiq/minireq/releases/tag/v0.2.0
 [0.1.1]: https://github.com/quartiq/minireq/releases/tag/v0.1.1
 [0.1.0]: https://github.com/quartiq/minireq/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,12 @@ heapless = {version = "0.7", features = ["serde"] }
 log = "0.4"
 serde = { version = "1", features = ["derive"], default-features = false }
 smlang = "0.6"
-embedded-io = "0.5"
+embedded-io = "0.6"
 
 [dev-dependencies]
 std-embedded-time = "0.1"
 tokio = { version = "1.9", features = ["rt-multi-thread", "time", "macros"] }
-env_logger = "0.9"
+env_logger = "0.10"
 embedded-nal = "0.7"
 serde-json-core = "0.5"
-
-[dev-dependencies.std-embedded-nal]
-git = "https://gitlab.com/ryan-summers/std-embedded-nal.git"
-branch = "feature/0.7"
+std-embedded-nal = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minireq"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Ryan Summers <ryan.summers@vertigo-designs.com>"]
 license = "MIT"
@@ -10,7 +10,7 @@ categories = ["no-std", "config", "embedded", "parsing"]
 repository = "https://github.com/quartiq/minireq"
 
 [dependencies]
-minimq = {git = "https://github.com/quartiq/minimq"}
+minimq = { version = "0.8.0" }
 heapless = {version = "0.7", features = ["serde"] }
 log = "0.4"
 serde = { version = "1", features = ["derive"], default-features = false }


### PR DESCRIPTION
* [x] waiting for minimq release after https://github.com/quartiq/minimq/pull/153
* release 0.3.0 chores